### PR TITLE
Fix incorrect package name for pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine
 
 # Install duply and backblaze bindings
 RUN apk update; \
-    apk add dumb-init duply py2-pip; \
+    apk add dumb-init duply py3-pip; \
     pip install b2; \
     mkdir /data; \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
The alpine repositories don't contain a package called py2-pip (anymore?) so the command was failing and none of the packages were getting installed. The py3-pip package works fine.